### PR TITLE
feat: 設定画面の追加と背景画像表示の制御

### DIFF
--- a/WeatherApp/AppSettings.swift
+++ b/WeatherApp/AppSettings.swift
@@ -1,0 +1,7 @@
+
+import Foundation
+import SwiftUI
+
+class AppSettings: ObservableObject {
+    @AppStorage("showBackgroundImage") var showBackgroundImage: Bool = true
+}

--- a/WeatherApp/Views/SettingsView.swift
+++ b/WeatherApp/Views/SettingsView.swift
@@ -1,0 +1,35 @@
+
+import SwiftUI
+
+struct SettingsView: View {
+    @Binding var showingSettingsSheet: Bool
+    @State private var showBackgroundColor = false // Dummy state for toggle
+
+    var body: some View {
+        NavigationView {
+            List {
+                Toggle(isOn: $showBackgroundColor) {
+                    Text("背景色を表示する")
+                }
+            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        showingSettingsSheet = false // Close the sheet
+                    }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.gray)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView(showingSettingsSheet: .constant(true))
+    }
+}

--- a/WeatherApp/Views/SettingsView.swift
+++ b/WeatherApp/Views/SettingsView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 
 struct SettingsView: View {
     @Binding var showingSettingsSheet: Bool
-    @State private var showBackgroundColor = false // Dummy state for toggle
+    @EnvironmentObject var appSettings: AppSettings
 
     var body: some View {
         NavigationView {
             List {
-                Toggle(isOn: $showBackgroundColor) {
+                Toggle(isOn: $appSettings.showBackgroundImage) {
                     Text("背景色を表示する")
                 }
             }

--- a/WeatherApp/Views/WeatherView.swift
+++ b/WeatherApp/Views/WeatherView.swift
@@ -107,10 +107,23 @@ struct WeatherView: View {
                 await viewModel.fetchWeather()
             }
             .sheet(isPresented: $showingSettingsSheet) {
-                // Half modal content (empty for now)
-                Text("Settings")
-                    .font(.largeTitle)
-                    .presentationDetents([.medium, .large]) // For half modal behavior
+                NavigationView {
+                    Text("Settings")
+                        .font(.largeTitle)
+                        .navigationTitle("Settings")
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarTrailing) {
+                                Button(action: {
+                                    showingSettingsSheet = false // Close the sheet
+                                }) {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.gray)
+                                }
+                            }
+                        }
+                }
+                .presentationDetents([.medium, .large]) // For half modal behavior
             }
         }
     }

--- a/WeatherApp/Views/WeatherView.swift
+++ b/WeatherApp/Views/WeatherView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct WeatherView: View {
     
     @StateObject private var viewModel = WeatherViewModel()
+    @State private var showingSettingsSheet = false
     
     var body: some View {
         NavigationView {
@@ -90,7 +91,7 @@ struct WeatherView: View {
                     }
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button(action: {
-                            // Setting button action
+                            showingSettingsSheet = true // Set to true to show the sheet
                         }) {
                             Image(systemName: "gearshape.fill")
                                 .foregroundStyle(.white)
@@ -104,6 +105,12 @@ struct WeatherView: View {
             }
             .task {
                 await viewModel.fetchWeather()
+            }
+            .sheet(isPresented: $showingSettingsSheet) {
+                // Half modal content (empty for now)
+                Text("Settings")
+                    .font(.largeTitle)
+                    .presentationDetents([.medium, .large]) // For half modal behavior
             }
         }
     }

--- a/WeatherApp/Views/WeatherView.swift
+++ b/WeatherApp/Views/WeatherView.swift
@@ -11,12 +11,13 @@ struct WeatherView: View {
     
     @StateObject private var viewModel = WeatherViewModel()
     @State private var showingSettingsSheet = false
+    @EnvironmentObject var appSettings: AppSettings
     
     var body: some View {
         NavigationView {
             ZStack {
                 // Background Image
-                if let url = viewModel.backgroundImageURL {
+                if appSettings.showBackgroundImage, let url = viewModel.backgroundImageURL {
                     AsyncImage(url: url) {
                         phase in
                         switch phase {
@@ -36,7 +37,7 @@ struct WeatherView: View {
                     .edgesIgnoringSafeArea(.all)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    Color.clear
+                    Color.gray
                 }
 
                 // Main Content

--- a/WeatherApp/Views/WeatherView.swift
+++ b/WeatherApp/Views/WeatherView.swift
@@ -107,23 +107,8 @@ struct WeatherView: View {
                 await viewModel.fetchWeather()
             }
             .sheet(isPresented: $showingSettingsSheet) {
-                NavigationView {
-                    Text("Settings")
-                        .font(.largeTitle)
-                        .navigationTitle("Settings")
-                        .navigationBarTitleDisplayMode(.inline)
-                        .toolbar {
-                            ToolbarItem(placement: .navigationBarTrailing) {
-                                Button(action: {
-                                    showingSettingsSheet = false // Close the sheet
-                                }) {
-                                    Image(systemName: "xmark.circle.fill")
-                                        .foregroundStyle(.gray)
-                                }
-                            }
-                        }
-                }
-                .presentationDetents([.medium, .large]) // For half modal behavior
+                SettingsView(showingSettingsSheet: $showingSettingsSheet)
+                    .presentationDetents([.medium, .large]) // For half modal behavior
             }
         }
     }

--- a/WeatherApp/WeatherApp.swift
+++ b/WeatherApp/WeatherApp.swift
@@ -9,9 +9,12 @@ import SwiftUI
 
 @main
 struct WeatherApp: App {
+    @StateObject var appSettings = AppSettings()
+
     var body: some Scene {
         WindowGroup {
             WeatherView()
+                .environmentObject(appSettings)
         }
     }
 }


### PR DESCRIPTION
## 概要

このPull Requestでは、以下の主要な機能追加と改善を行っています。

- **設定画面（ハーフモーダル）の追加**:
  - ナビゲーションバーの設定ボタンをタップすると、ハーフモーダル形式の設定画面が表示されるようにしました。
  - 設定画面にはナビゲーションバーと閉じるためのXボタンを設置しました。

- **背景画像表示の制御機能**:
  - 設定画面内に「背景色を表示する」というトグルを追加しました。
  - このトグルの状態に応じて、`WeatherView`の背景画像（Unsplashから取得）の表示・非表示を切り替えるようにしました。
  - トグルの状態はアプリ起動時デフォルトでONとし、ユーザーが設定を変更してもその状態が永続化されるようにしました。
  - ロケーションを変更した場合でも、トグルの状態に応じて背景表示が適切に切り替わることを確認しました。

## 変更内容

- `WeatherView.swift`:
  - 設定シートの表示状態を管理する `@State` 変数 `showingSettingsSheet` を追加。
  - 設定ボタンのアクションで `showingSettingsSheet` を `true` に設定。
  - `.sheet` モディファイアを追加し、`SettingsView` を表示するように変更。
- `SettingsView.swift` (新規作成):
  - ハーフモーダルの内容を定義するビュー。
  - ナビゲーションバー、タイトル、閉じるボタン（Xボタン）を設置。
  - 「背景色を表示する」トグルを配置し、`AppSettings` の `showBackgroundImage` プロパティにバインド。
- `AppSettings.swift` (新規作成):
  - アプリ全体の設定を管理する `ObservableObject`。
  - `@AppStorage` を使用して `showBackgroundImage` プロパティを永続化。
- `WeatherApp.swift`:
  - `AppSettings` を環境オブジェクトとして注入し、アプリ全体で利用可能に。

## 動作確認

- ナビゲーションバーの設定ボタンをタップすると、ハーフモーダルが正しく表示されること。
- ハーフモーダル内のXボタンをタップすると、モーダルが閉じられること。
- 「背景色を表示する」トグルをON/OFFすると、`WeatherView`の背景画像が適切に表示/非表示されること。
- アプリを再起動してもトグルの状態が維持されること。
- ロケーションを変更しても、トグルの状態が背景表示に反映されること。
